### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To only display the tip one time just call displayOneTime(int showtipId) on the 
 
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-ShowTipsView-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1132)
 
-##Download
+## Download
 **Gradle:**
 ```
 compile 'net.fredericosilva:showTipsView:1.0.4'


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
